### PR TITLE
Add note about VS2022's treat angle brackets as external feature

### DIFF
--- a/02-Use_the_Tools_Available.md
+++ b/02-Use_the_Tools_Available.md
@@ -161,6 +161,7 @@ Consider using `-Weverything` and disabling the few warnings you need to on Clan
 Not recommended
 
  * `/Wall` - Also warns on files included from the standard library, so it's not very useful and creates too many extra warnings.
+   * Since VS2022, `/external:anglebrackets /external:W0` can be used to turn off warnings from all headers included with angle brackets, e.g. `#include <utility>`.
 
 
 


### PR DESCRIPTION
This is a really good way to temporarily develop with `/Wall` enabled, then switching back to `/W4` after fixing all of the extra warnings.

You can also disable other types of diagnostics in STL headers, e.g. `/external:templates-`, `/analyze:external-`.