### PR TITLE
Fix link to PDF in "Considering Correctness"

### DIFF
--- a/09-Considering_Correctness.md
+++ b/09-Considering_Correctness.md
@@ -25,4 +25,4 @@ Consider using a typesafe library like
 
 Note that stronger typing can also allow for more compiler optimizations.
 
-* [Sorting in C vs C++](Sorting in C vs C++.pdf)
+* [Sorting in C vs C++](Sorting%20in%20C%20vs%20C++.pdf)


### PR DESCRIPTION
Github does not render link if it contains bare spaces. URL-encoding them fixes the issue.