### PR TITLE
Add GLIBCXX_ASSERTIONS to recommended compiler flags

### DIFF
--- a/02-Use_the_Tools_Available.md
+++ b/02-Use_the_Tools_Available.md
@@ -126,6 +126,7 @@ You should use as many compilers as you can for your platform(s). Each compiler 
  * `-Wformat=2` warn on security issues around functions that format output (i.e., `printf`)
  * `-Wlifetime` (only special branch of Clang currently) shows object lifetime issues
  * `-Wimplicit-fallthrough` Warns when case statements fall-through. (Included with `-Wextra` in GCC, not in clang)
+ * `-D_GLIBCXX_ASSERTIONS` (only in GCC >= TBD) Adds extra assertions, null pointer checks. Do not enable this on release builds because it is slow.
 
 Consider using `-Weverything` and disabling the few warnings you need to on Clang
 


### PR DESCRIPTION
When migrating legacy code from `uint8_t my_arr[N]`  to `std::array<uint8_t, N>`, there are places where bracket access is used. This does not perform bounds checking, even at compile time.

For example, you could construct an array with 6 elements, then access element 42 at runtime with no errors, even with all the flags enabled that are currently recommended.
https://godbolt.org/z/3KWqe1vbs

Even if you set `-Weverything` and compile in clang, it's not caught.

I figured out you can enable bounds checking on bracket access with `GLIBCXX_ASSERTIONS`
https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_macros.html

There are runtime costs with bounds checking, so it should [not be enabled in production](https://gitlab.psi.ch/OPAL/src/-/merge_requests/468), however this would be great flag to add to a debug build that is tested in CI.


```c++
#include <array>
#include <iostream>

int main() {

    std::array<double, 6> a;
    std::cout << "The UB value of a is " << a[42] << std::endl;
    return 0;
}
```